### PR TITLE
Codeanalysis Merge

### DIFF
--- a/BattleRegen/BattleRegen.csproj
+++ b/BattleRegen/BattleRegen.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Microsoft.CodeAnalysis.Analyzers.2.9.6\build\Microsoft.CodeAnalysis.Analyzers.props" Condition="Exists('packages\Microsoft.CodeAnalysis.Analyzers.2.9.6\build\Microsoft.CodeAnalysis.Analyzers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -61,11 +62,17 @@
     <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Lib.Harmony.2.0.4\lib\net48\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="MCMv4, Version=4.3.5.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>packages\Bannerlord.MCM.4.3.5\lib\net472\MCMv4.dll</HintPath>
+    <Reference Include="MCMv4, Version=4.3.6.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>packages\Bannerlord.MCM.4.3.6\lib\net472\MCMv4.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=3.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.CodeAnalysis.Common.3.4.0\lib\netstandard2.0\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=3.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.CodeAnalysis.CSharp.3.4.0\lib\netstandard2.0\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=3.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.CodeAnalysis.VisualBasic.3.4.0\lib\netstandard2.0\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualBasic">
@@ -78,12 +85,30 @@
     <Reference Include="System">
       <Private>False</Private>
     </Reference>
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core">
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Linq" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
       <Private>False</Private>
@@ -92,6 +117,12 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encoding.CodePages.4.5.1\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Threading.Tasks.Extensions.4.5.3\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Xml.Linq">
       <Private>False</Private>
@@ -163,16 +194,19 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="packages\Microsoft.CodeAnalysis.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="packages\Microsoft.CodeAnalysis.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.CodeAnalysis.Analyzers.2.9.6\build\Microsoft.CodeAnalysis.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeAnalysis.Analyzers.2.9.6\build\Microsoft.CodeAnalysis.Analyzers.props'))" />
   </Target>
 </Project>

--- a/BattleRegen/BattleRegeneration.cs
+++ b/BattleRegen/BattleRegeneration.cs
@@ -25,7 +25,7 @@ namespace BattleRegen
             heroXpGainPairs = new ConcurrentQueue<Tuple<Hero, double>>();
 
             Debug.Print("[BattleRegeneration] Mission started, data initialized");
-            Debug.Print($"[BattleRegeneration] Debug mode on, dumping settings: " +
+            Debug.Print($"[BattleRegeneration] Debug mode on, dumping settings: regen mode: {settings.RegenModel}, " +
                 $"medicine boost: {settings.RegenAmount}, regen model: {settings.MedicineBoost}, commander medicine boost: {settings.CommanderMedicineBoost}, " +
                 $"xp gain: {settings.XpGain}, commander xp gain: {settings.CommanderXpGain}, " +
                 $"regen in percent HP: player:{settings.RegenAmount}, companions:{settings.RegenAmountCompanions}, allied heroes:{settings.RegenAmountAllies}, " +

--- a/BattleRegen/Formula.cs
+++ b/BattleRegen/Formula.cs
@@ -1,8 +1,10 @@
 ﻿using HarmonyLib;
 using MCM.Abstractions.Dropdown;
-using Microsoft.CodeDom.Providers.DotNetCompilerPlatform;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic;
 using System;
-using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -26,6 +28,8 @@ namespace BattleRegen
         private static readonly string ModulesPath = System.IO.Path.Combine(BasePath.Name, "Modules");
 
         private static List<ModuleInfo> Modules { get; } = new List<ModuleInfo>();
+
+        private static readonly HashSet<string> loadedFiles = new HashSet<string>();
 
         private static List<Formula> formulas = InitializeFormulas();
 
@@ -99,51 +103,78 @@ namespace BattleRegen
             return comparison == 0 ? Id.CompareTo(other.Id) : comparison;
         }
 
+        #region internal methods
         internal static DropdownDefault<Formula> GetFormulas()
         {
             return new DropdownDefault<Formula>(formulas, 0);
         }
 
-        private static void CompileCode(CodeDomProvider codeProvider, CompilerParameters parameters, FileInfo codeFile)
+        [CommandLineFunctionality.CommandLineArgumentFunction("list_scripts", "battleregen")]
+        internal static string ListScripts(List<string> strings)
         {
-            try
+            return loadedFiles.Join(delimiter: "\n");
+        }
+
+        private static void CompileCode(FileInfo codeFile, Func<FileInfo, Compilation> function)
+        {
+            using (var stream = new MemoryStream())
             {
-                CompilerResults results = codeProvider.CompileAssemblyFromFile(parameters, codeFile.FullName);
+                var results = function(codeFile).Emit(stream);
+                var diagnostics = results.Diagnostics;
+                diagnostics.Do(x => Debug.Print($"[BattleRegen] {x}"));
 
-                if (results.Errors.Count > 0)
+                if (diagnostics.Any(x => x.Severity == DiagnosticSeverity.Error || x.IsWarningAsError))
                 {
-                    foreach (CompilerError error in results.Errors)
-                        Debug.Print($"[BattleRegen] {error}");
-
-                    if (!results.Errors.HasErrors)
-                        Debug.Print($"[BattleRegen] Compilation of {codeFile.FullName} generated warnings. See above for details.");
-                    else
-                    {
-                        Debug.Print($"[BattleRegen] Compilation of {codeFile.FullName} failed. See above for details.");
-                        return;
-                    }
+                    Debug.Print($"[BattleRegen] Compilation of {codeFile.FullName} failed. See above for details.");
+                    return;
                 }
+                else
+                    Debug.Print($"[BattleRegen] Compilation of {codeFile.FullName} generated warnings. See above for details.");
                 Debug.Print($"[BattleRegen] {codeFile.FullName} compiled successfully.");
 
-                Assembly compiledCode = results.CompiledAssembly;
-                var types = compiledCode.GetTypes().Where(x => typeof(Formula).IsAssignableFrom(x));
+                stream.Seek(0, SeekOrigin.Begin);
+                var assembly = Assembly.Load(stream.ToArray());
+                loadedFiles.Add(codeFile.FullName);
+                var types = assembly.GetTypes().Where(x => typeof(Formula).IsAssignableFrom(x));
 
                 if (types.IsEmpty())
                     Debug.Print($"[BattleRegen] No class derived from {typeof(Formula).FullName} exists from {codeFile.FullName}.");
                 else types.Do(x => AddFormula(x));
             }
-            catch (Exception e)
+        }
+
+        private static Compilation GenerateCSharpCode(FileInfo codeFile)
+        {
+            using (var stream = codeFile.OpenRead())
             {
-                string error = $"[BattleRegen] Failed to load file {codeFile.FullName}\n\nError: {e}";
-                Debug.Print(error);
-                InformationManager.DisplayMessage(new InformationMessage(error));
+                var codestr = SourceText.From(stream);
+                var options = CSharpParseOptions.Default.WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_3);
+                var syntaxTree = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseSyntaxTree(codestr, options);
+                return CSharpCompilation.Create(System.IO.Path.GetRandomFileName(), new[] { syntaxTree },
+                    GetReferences(), new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
             }
+        }
+
+        private static Compilation GenerateVisualBasicCode(FileInfo codeFile)
+        {
+            using (var stream = codeFile.OpenRead())
+            {
+                var codestr = SourceText.From(stream);
+                var options = VisualBasicParseOptions.Default.WithLanguageVersion(Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic16);
+                var syntaxTree = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseSyntaxTree(codestr, options);
+                return VisualBasicCompilation.Create(System.IO.Path.GetRandomFileName(), new[] { syntaxTree },
+                    GetReferences(), new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            }
+        }
+
+        private static IEnumerable<MetadataReference> GetReferences()
+        {
+            return AppDomain.CurrentDomain.GetAssemblies().Where(x => !x.IsDynamic).Select(x => x.Location).Where(x => !x.IsEmpty())
+                .Select(x => MetadataReference.CreateFromFile(x));
         }
 
         internal static List<Formula> InitializeFormulas()
         {
-            Debug.Print("[BattleRegen] Compiling all formulas. This could take a while.");
-
             // Shamelessly copied from Custom Troop Upgrades because it's my mod
             if (!Modules.IsEmpty()) Modules.Clear();
             
@@ -158,41 +189,40 @@ namespace BattleRegen
             }
 
             formulas = new List<Formula>();
-            // Set up compilers options
-            ProviderOptions csOptions = new ProviderOptions(System.IO.Path.Combine(ModulesPath, Modules[0].Id, "bin", "Win64_Shipping_Client", "roslyn", "csc.exe"), 60);
-            ProviderOptions vbOptions = new ProviderOptions(System.IO.Path.Combine(ModulesPath, Modules[0].Id, "bin", "Win64_Shipping_Client", "roslyn", "vbc.exe"), 60);
-            CSharpCodeProvider csCodeProvider = new CSharpCodeProvider(csOptions);
-            VBCodeProvider vbCodeProvider = new VBCodeProvider(vbOptions);
-            CompilerParameters parameters = new CompilerParameters
-            {
-                GenerateExecutable = false,
-                GenerateInMemory = true
-            };
-            try
-            {
-                parameters.ReferencedAssemblies.AddRange(AppDomain.CurrentDomain.GetAssemblies().Where(x => !x.IsDynamic)
-                    .Select(x => x.Location).Where(x => !x.IsEmpty()).ToArray());
-            }
-            catch (Exception e)
-            {
-                Debug.Print($"[BattleRegen] Failed to add all required assemblies.\n\n{e}");
-            }
+            CompileScripts("battleregen.cs", GenerateCSharpCode);
+            CompileScripts("battleregen.vb", GenerateVisualBasicCode);
+            return formulas;
+        }
+        #endregion
 
-            foreach (ModuleInfo module in Modules)
+        /// <summary>
+        /// Compiles scripts from source files with a given extension and the compilation function. If a directory is specified, source files
+        /// from said directory will be compiled. Otherwise, source files from ModuleData folders of all modules will be loaded.
+        /// </summary>
+        /// <param name="extension">The extension of source files.</param>
+        /// <param name="function">The function used to compile source files.</param>
+        /// <param name="sourcePath">Directory of source files. If specified, source files from the directory will be compiled. Otherwise,
+        /// source files from ModuleData folders of all modules will be loaded.</param>
+        public static void CompileScripts(string extension, Func<FileInfo, Compilation> function, DirectoryInfo sourcePath = default)
+        {
+            Debug.Print($"[BattleRegen] Compiling formulas from source files of extension '{extension}'. This could take a while.");
+            if (sourcePath != default && sourcePath.Exists)
             {
-                DirectoryInfo dataPath = new DirectoryInfo(System.IO.Path.Combine(ModulesPath, module.Id, "ModuleData"));
-                if (dataPath.Exists)
+                Debug.Print($"[BattleRegen] Loading source files from {sourcePath.FullName}");
+                sourcePath.EnumerateFiles($"*.{extension}").Where(x => !loadedFiles.Contains(x.FullName)).Do(x => CompileCode(x, function));
+            }
+            else
+            {
+                Debug.Print("[BattleRegen] Loading source files from the ModuleData folders (if available) of all modules");
+                foreach (ModuleInfo module in Modules)
                 {
-                    foreach (FileInfo csFile in dataPath.EnumerateFiles("*.battleregen.cs"))
-                        CompileCode(csCodeProvider, parameters, csFile);
-                    foreach (FileInfo vbFile in dataPath.EnumerateFiles("*.battleregen.vb"))
-                        CompileCode(vbCodeProvider, parameters, vbFile);
+                    DirectoryInfo dataPath = new DirectoryInfo(System.IO.Path.Combine(ModulesPath, module.Id, "ModuleData"));
+                    if (dataPath.Exists)
+                        dataPath.EnumerateFiles($"*.{extension}").Where(x => !loadedFiles.Contains(x.FullName)).Do(x => CompileCode(x, function));
                 }
             }
-
             formulas.Sort();
-            Debug.Print("[BattleRegen] Loaded all installed regeneration formulas. See mod entry in MCM for details.");
-            return formulas;
+            Debug.Print($"[BattleRegen] Loaded regeneration formulas from source files of extension '{extension}'. See mod entry in MCM for details.");
         }
 
         /// <summary>

--- a/BattleRegen/Formula.cs
+++ b/BattleRegen/Formula.cs
@@ -151,7 +151,7 @@ namespace BattleRegen
                 var options = CSharpParseOptions.Default.WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_3);
                 var syntaxTree = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseSyntaxTree(codestr, options);
                 return CSharpCompilation.Create(System.IO.Path.GetRandomFileName(), new[] { syntaxTree },
-                    GetReferences(), new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                    GetReferences(), new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, deterministic: true));
             }
         }
 
@@ -163,12 +163,43 @@ namespace BattleRegen
                 var options = VisualBasicParseOptions.Default.WithLanguageVersion(Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic16);
                 var syntaxTree = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseSyntaxTree(codestr, options);
                 return VisualBasicCompilation.Create(System.IO.Path.GetRandomFileName(), new[] { syntaxTree },
-                    GetReferences(), new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                    GetReferences(), new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, deterministic: true));
             }
         }
 
         private static IEnumerable<MetadataReference> GetReferences()
         {
+            // test to see if this causes an issue
+            //try
+            //{
+            //    var locations = AppDomain.CurrentDomain.GetAssemblies().Where(x => !x.IsDynamic).Select(x => x.Location).Where(x => !x.IsEmpty());
+            //    var resolver = new PathAssemblyResolver(locations);
+            //    using (var mlc = new MetadataLoadContext(resolver))
+            //    {
+            //        foreach (var location in locations)
+            //        {
+            //            Assembly assembly = mlc.LoadFromAssemblyPath(location);
+            //            AssemblyName name = assembly.GetName();
+
+            //            string output = $"[BattleRegen] Debug: {name.Name} has the following attributes:\n";
+            //            foreach (CustomAttributeData attr in assembly.GetCustomAttributesData())
+            //            {
+            //                try
+            //                {
+            //                    output += $"{attr.AttributeType}\n";
+            //                }
+            //                catch (FileNotFoundException)
+            //                {
+            //                }
+            //            }
+            //            Debug.Print(output);
+            //        }
+            //    }
+            //}
+            //catch (Exception e)
+            //{
+            //    Debug.Print($"[BattleRegen] Debug: An exception has occured attempting to obtain metadata. See above for possible cause.\n{e}");
+            //}
             return AppDomain.CurrentDomain.GetAssemblies().Where(x => !x.IsDynamic).Select(x => x.Location).Where(x => !x.IsEmpty())
                 .Select(x => MetadataReference.CreateFromFile(x));
         }

--- a/BattleRegen/packages.config
+++ b/BattleRegen/packages.config
@@ -1,6 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bannerlord.MCM" version="4.3.5" targetFramework="net48" />
+  <package id="Bannerlord.MCM" version="4.3.6" targetFramework="net48" />
   <package id="Lib.Harmony" version="2.0.4" targetFramework="net48" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="2.9.6" targetFramework="net48" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="3.4.0" targetFramework="net48" />
+  <package id="Microsoft.CodeAnalysis.Compilers" version="3.4.0" targetFramework="net48" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="3.4.0" targetFramework="net48" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="3.4.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net48" />
+  <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net48" />
+  <package id="System.Text.Encoding.CodePages" version="4.5.1" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Changelog:
* Switched to Roslyn/.NET Compiler Service (Microsoft.CodeAnalysis library set). Somehow the resulting mod file is even larger.
* Added a method to Formula class enabling scripts in other languages to be compiled using Roslyn/.NET Compiler Service.
* Fixed unable to compile scripts due to obfuscated assemblies being referenced.

Todo:
* Might consider moving the compiler service into another mod that loads before main Bannerlord modules... Will have to contact Aragas on this one due to the shared usage of several libraries by ButterLib.
* If above, consider moving formula code into the library.
* Might consider allowing re-running of built-in compilation functions.